### PR TITLE
Fix for apt's cache being empty

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,7 @@ test:
     - n=test-publish-all; docker run -d --name $n -P nginx && sleep 3 && curl $(docker port $n | grep 80 |awk '{print $3}')
 
     # Test --link
-    - n=test-link; docker run -d --name $n nginx && docker run --link $n ubuntu bash -c "apt-get install -y curl && curl $n"
+    - n=test-link; docker run -d --name $n nginx && docker run --link $n ubuntu bash -c "apt-get update && apt-get install -y curl && curl $n"
 
     # Test -v (--volume)
     - echo "mount me" > ./mountme.txt && docker run -v /home/ubuntu/docker:/tmp/test-vol ubuntu cat /tmp/test-vol/mountme.txt


### PR DESCRIPTION
I believe the only thing stopping CI from passing is the apt-cache is cleared by default in the base ubuntu image
